### PR TITLE
fix: duration as bigint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
   "extends": ["plugin:security/recommended", "plugin:prettier/recommended"],
   "plugins": ["security", "prettier"],
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   },
   "overrides": [
     {

--- a/src/index.js
+++ b/src/index.js
@@ -90,8 +90,8 @@ async function sendOperation(syncedQueries, schemaHash, profile, requestContext,
 }
 
 function getDuration(startTime) {
-  const [seconds, nanos] = process.hrtime(startTime)
-  return seconds * 1e9 + nanos
+  const endTime = process.hrtime.bigint()
+  return Number((endTime - startTime) / 1000n)
 }
 
 function pathAsString(resolver) {
@@ -154,7 +154,7 @@ function LogqlApolloPlugin(options = Object.create(null)) {
 
     requestDidStart({ logger }) {
       // See https://stackoverflow.com/questions/18031839/how-to-use-process-hrtime-to-get-execution-time-of-async-function
-      const requestStartTime = process.hrtime()
+      const requestStartTime = process.hrtime.bigint()
       const profile = {
         receivedAt: new Date().toISOString(),
         resolvers: [],


### PR DESCRIPTION
Use `Bigint` for intermediate calculation when measuring duration, but still cast it as `Number` at the end.
Breaking: Divide by 1000 to get result in `ms` instead of `ns`