### PR TITLE
fix: profile.resolvers.end can be undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ const { json, text, sendWithRetry } = require('./client')
  * @typedef {Object} Resolver
  * @property {(string | number)[]} path
  * @property {number} start
- * @property {number} [end]
- * @property {boolean} [error]
+ * @property {number} end
+ * @property {boolean} error
  *
  * @typedef {Object} Profile
  * @property {string} receivedAt
@@ -335,15 +335,16 @@ function LogqlApolloPlugin(options = Object.create(null)) {
               profile.executionEnd = getDuration(requestStartTime)
             },
             willResolveField({ info }) {
-              const resolver = {
-                path: responsePathAsArray(info.path),
-                start: getDuration(requestStartTime),
-              }
-              profile.resolvers.push(resolver)
+              const start = getDuration(requestStartTime)
 
               return function didResolveField(error) {
-                resolver.end = getDuration(requestStartTime)
-                resolver.error = !!error
+                const end = getDuration(requestStartTime)
+                profile.resolvers.push({
+                  path: responsePathAsArray(info.path),
+                  error: !!error,
+                  start,
+                  end,
+                })
               }
             },
           }

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -1985,86 +1985,7 @@ describe('Request handling with Apollo Server', () => {
         parsingStart: expect.any(Number),
         receivedAt: expect.any(String),
         requestEnd: expect.any(Number),
-        resolvers: [
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'id'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'name'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'group'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'group', 'id'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'group', 'name'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'group', 'users'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'group', 'users', 0, 'id'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'group', 'users', 0, 'name'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: true,
-            path: ['user', 'group', 'users', 0, 'avatar'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'group', 'users', 1, 'id'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: false,
-            path: ['user', 'group', 'users', 1, 'name'],
-            start: expect.any(Number),
-          },
-          {
-            end: expect.any(Number),
-            error: true,
-            path: ['user', 'group', 'users', 1, 'avatar'],
-            start: expect.any(Number),
-          },
-        ],
+        resolvers: expect.any(Array),
         validationEnd: expect.any(Number),
         validationStart: expect.any(Number),
       },
@@ -2087,6 +2008,89 @@ describe('Request handling with Apollo Server', () => {
         stackTrace: expect.stringMatching('Error: Failed to load avatar: file does not exists'),
       })),
     })
+    expect(payload.profile.resolvers).toEqual(
+      expect.arrayContaining([
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'id'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'name'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'group'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'group', 'id'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'group', 'name'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'group', 'users'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'group', 'users', 0, 'id'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'group', 'users', 0, 'name'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: true,
+          path: ['user', 'group', 'users', 0, 'avatar'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'group', 'users', 1, 'id'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: false,
+          path: ['user', 'group', 'users', 1, 'name'],
+          start: expect.any(Number),
+        },
+        {
+          end: expect.any(Number),
+          error: true,
+          path: ['user', 'group', 'users', 1, 'avatar'],
+          start: expect.any(Number),
+        },
+      ])
+    )
+    expect(payload.profile.resolvers).toHaveLength(13)
     expect(report).toEqual({
       schemaHash,
       operations: [


### PR DESCRIPTION
This fix a bug when `profile.resolvers.end` is undefined during ingestion. Not sure why this happen but removing the field from the profile when the end hook isn't called.