### PR TITLE
Handle persisted query not found

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -106,7 +106,9 @@ async function sendWithRetry(path, data, config, logger) {
     )
     return true
   } catch (err) {
-    logger.error(`[logql-plugin][ERROR][client] request failed ${url}: ${err}`)
+    if (config.verbose) {
+      logger.error(`[logql-plugin][ERROR][client] request failed ${url}: ${err}`)
+    }
     return false
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,13 @@ function pathAsString(resolver) {
 }
 
 /**
+ * @param {RequestContext} requestContext
+ */
+function isPersistedQueryNotFound({ request, source, errors }) {
+  return errors && !source && request.http?.method === 'GET'
+}
+
+/**
  * @param {Partial<Config>} options
  * @returns {import('@apollo/server').ApolloServerPlugin}
  */
@@ -358,6 +365,9 @@ function LogqlApolloPlugin(options = Object.create(null)) {
           }
         },
         async willSendResponse(requestContext) {
+          if (isPersistedQueryNotFound(requestContext)) {
+            return
+          }
           requestWillBeSent(requestContext)
           if (requestContext.errors || Math.random() < config.sampling) {
             sendError(requestContext.errors, schemaHash, profile, requestContext, config, logger)


### PR DESCRIPTION
Stop reporting when persisted query is not found.
Stop logging when verbose mode is off