### PR TITLE
feat(BREAKING): Explicitly get config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,19 @@ yarn add @logql/apollo-plugin
 ## Usage
 
 ```js
-const Logql = require('@logql/apollo-plugin')
+const logql = require('@logql/apollo-plugin')
 
 // ...
+
+const logqlPlugin = logql({ apiKey: 'logql:your-api-key' })
+
+// or using environment variables for config:
+
+const logqlPlugin = logql.fromEnv()
 
 const apolloServer = new ApolloServer({
   typeDefs,
   resolvers,
-  plugins: [
-    Logql({
-      apiKey: 'logql:your-api-key,
-    }),
-  ],
+  plugins: [logqlPlugin],
 })
-```
-
-Or using environment variables:
-
-```sh
-LOGQL_API_KEY=logql:your-api-key node .
 ```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "async-retry": "^1.2.1",
-    "envalid": "^7.3.1",
     "lru-cache": "^10.0.0",
     "node-fetch": "^2.6.7",
     "zod": "^3.20.2",

--- a/src/config.js
+++ b/src/config.js
@@ -1,111 +1,83 @@
 // @ts-check
 const http = require('http')
 const https = require('https')
-const { cleanEnv, str, num, bool, url } = require('envalid')
 const { z } = require('zod')
 const { fromZodError } = require('zod-validation-error')
 
 const ConfigSchema = z.object({
   apiKey: z.string().startsWith('logql:'),
   environment: z.string().trim().toLowerCase().max(128).default(''),
-  timeout: z.number().min(0).default(2000),
+  endpoint: z.string().url().default('https://ingress.logql.io'),
+
   sendVariables: z.boolean().default(false),
   sendHeaders: z.boolean().default(false),
   runInTests: z.boolean().default(false),
   verbose: z.boolean().default(false),
-  reportIntervalMs: z.number().min(0).default(5000),
-  reportEntriesThreshold: z.number().min(1).default(1024),
-  cacheSize: z.number().min(1).default(16384),
+
+  timeout: z.number().int().nonnegative().default(2000),
+  reportIntervalMs: z.number().int().nonnegative().default(5000),
+  reportEntriesThreshold: z.number().int().positive().default(1024),
+  cacheSize: z.number().int().positive().default(16384),
+
   sampling: z.number().min(0).max(1).default(1.0),
-  endpoint: z.string().url().default('https://ingress.logql.io'),
+
   agent: z.instanceof(http.Agent).or(z.instanceof(https.Agent)).nullable().default(null),
 })
 
-/**
- * @typedef {z.infer<typeof ConfigSchema>} Config
- */
+/** @typedef {z.infer<typeof ConfigSchema>} Config */
 
-/**
- * @param {string} msg
- */
+/** @param {string} msg */
 function logInitError(msg) {
   if (process.env.NODE_ENV !== 'test') {
     console.error(`[logql-plugin][ERROR][init] ${msg}`)
   }
 }
 
-/**
- * @param {string} msg
- */
-function logInitWarning(msg) {
-  if (process.env.NODE_ENV !== 'test') {
-    console.error(`[logql-plugin][WARNING][init] ${msg}`)
+/** @param {string | undefined} str */
+function Bool(str) {
+  if (str == null) return undefined
+  const num = Number(str)
+  return Number.isSafeInteger(num) ? Boolean(num) : str === 'true' || str === 't'
+}
+
+/** @param {string | undefined} str */
+function Num(str) {
+  if (str == null) return undefined
+  const num = Number(str)
+  if (Number.isNaN(num)) {
+    logInitError(`Invalid environment variable: Expected a number, got ${str}`)
   }
+  return num
 }
 
 function loadEnv() {
-  try {
-    return cleanEnv(
-      {
-        apiKey: process.env.LOGQL_API_KEY,
-        environment: process.env.LOGQL_ENVIRONMENT,
-        timeout: process.env.LOGQL_TIMEOUT,
-        sendVariables: process.env.LOGQL_SEND_VARIABLES,
-        sendHeaders: process.env.LOGQL_SEND_HEADERS,
-        runInTests: process.env.LOGQL_RUN_IN_TESTS,
-        verbose: process.env.LOGQL_VERBOSE,
-        reportIntervalMs: process.env.LOGQL_REPORT_INTERVAL_MS,
-        reportEntriesThreshold: process.env.LOGQL_REPORT_ENTRIES_THRESHOLD,
-        cacheSize: process.env.LOGQL_CACHE_SIZE,
-        sampling: process.env.LOGQL_SAMPLING,
-        endpoint: process.env.LOGQL_ENDPOINT,
-      },
-      {
-        apiKey: str({ default: undefined }),
-        environment: str({ default: undefined }),
-        timeout: num({ default: undefined }),
-        sendVariables: bool({ default: undefined }),
-        sendHeaders: bool({ default: undefined }),
-        runInTests: bool({ default: undefined }),
-        silent: bool({ default: undefined }),
-        reportIntervalMs: num({ default: undefined }),
-        reportEntriesThreshold: num({ default: undefined }),
-        cacheSize: num({ default: undefined }),
-        sampling: num({ default: undefined }),
-        endpoint: url({ default: undefined }),
-      },
-      {
-        // Mute the errors
-        reporter: ({ errors }) => {
-          const errorKeys = Object.keys(errors)
-          if (errorKeys.length) {
-            logInitWarning(
-              `Invalid values supplied as environment variables, ignoring: ${errorKeys
-                .map((envVar) => `${envVar}: ${errors[`${envVar}`].message}`)
-                .join(';')}`
-            )
-          }
-        },
-      }
-    )
-  } catch (err) /* istanbul ignore next */ {
-    logInitWarning(`Failed to load config from environment variables: ${err.message}`)
-    return {}
+  const config = {
+    apiKey: process.env.LOGQL_API_KEY,
+    environment: process.env.LOGQL_ENVIRONMENT,
+    endpoint: process.env.LOGQL_ENDPOINT,
+
+    sendVariables: Bool(process.env.LOGQL_SEND_VARIABLES),
+    sendHeaders: Bool(process.env.LOGQL_SEND_HEADERS),
+    runInTests: Bool(process.env.LOGQL_RUN_IN_TESTS),
+    verbose: Bool(process.env.LOGQL_VERBOSE),
+
+    timeout: Num(process.env.LOGQL_TIMEOUT),
+    reportIntervalMs: Num(process.env.LOGQL_REPORT_INTERVAL_MS),
+    reportEntriesThreshold: Num(process.env.LOGQL_REPORT_ENTRIES_THRESHOLD),
+    cacheSize: Num(process.env.LOGQL_CACHE_SIZE),
+    sampling: Num(process.env.LOGQL_SAMPLING),
   }
+  return config
 }
 
-/**
- * @param {unknown} options
- */
+/** @param {unknown} options */
 function getConfig(options) {
   if (typeof options !== 'object') {
     logInitError(`Invalid options type: Expected an object, got ${typeof options}`)
     return
   }
 
-  const env = loadEnv()
-
-  const maybeConfig = ConfigSchema.safeParse({ ...env, ...options })
+  const maybeConfig = ConfigSchema.safeParse(options)
   if (maybeConfig.success) {
     return maybeConfig.data
   }
@@ -117,4 +89,4 @@ function getConfig(options) {
   logInitError(validationError.message)
 }
 
-module.exports = { getConfig }
+module.exports = { getConfig, loadEnv }

--- a/src/config.js
+++ b/src/config.js
@@ -33,39 +33,48 @@ function logInitError(msg) {
   }
 }
 
-/** @param {string | undefined} str */
-function Bool(str) {
-  if (str == null) return undefined
+/** @param {string} envKey */
+function Str(envKey) {
+  const str = process.env[envKey]
+  if (str == null || str === '') return undefined
+  return str
+}
+
+/** @param {string} envKey */
+function Bool(envKey) {
+  const str = process.env[envKey]
+  if (str == null || str === '') return undefined
   const num = Number(str)
   return Number.isSafeInteger(num) ? Boolean(num) : str === 'true' || str === 't'
 }
 
-/** @param {string | undefined} str */
-function Num(str) {
-  if (str == null) return undefined
+/** @param {string} envKey */
+function Num(envKey) {
+  const str = process.env[envKey]
+  if (str == null || str === '') return undefined
   const num = Number(str)
   if (Number.isNaN(num)) {
-    logInitError(`Invalid environment variable: Expected a number, got ${str}`)
+    logInitError(`Invalid environment value for ${envKey}: Expected a number, got "${str}"`)
   }
   return num
 }
 
 function loadEnv() {
   const config = {
-    apiKey: process.env.LOGQL_API_KEY,
-    environment: process.env.LOGQL_ENVIRONMENT,
-    endpoint: process.env.LOGQL_ENDPOINT,
+    apiKey: Str('LOGQL_API_KEY'),
+    environment: Str('LOGQL_ENVIRONMENT'),
+    endpoint: Str('LOGQL_ENDPOINT'),
 
-    sendVariables: Bool(process.env.LOGQL_SEND_VARIABLES),
-    sendHeaders: Bool(process.env.LOGQL_SEND_HEADERS),
-    runInTests: Bool(process.env.LOGQL_RUN_IN_TESTS),
-    verbose: Bool(process.env.LOGQL_VERBOSE),
+    sendVariables: Bool('LOGQL_SEND_VARIABLES'),
+    sendHeaders: Bool('LOGQL_SEND_HEADERS'),
+    runInTests: Bool('LOGQL_RUN_IN_TESTS'),
+    verbose: Bool('LOGQL_VERBOSE'),
 
-    timeout: Num(process.env.LOGQL_TIMEOUT),
-    reportIntervalMs: Num(process.env.LOGQL_REPORT_INTERVAL_MS),
-    reportEntriesThreshold: Num(process.env.LOGQL_REPORT_ENTRIES_THRESHOLD),
-    cacheSize: Num(process.env.LOGQL_CACHE_SIZE),
-    sampling: Num(process.env.LOGQL_SAMPLING),
+    timeout: Num('LOGQL_TIMEOUT'),
+    reportIntervalMs: Num('LOGQL_REPORT_INTERVAL_MS'),
+    reportEntriesThreshold: Num('LOGQL_REPORT_ENTRIES_THRESHOLD'),
+    cacheSize: Num('LOGQL_CACHE_SIZE'),
+    sampling: Num('LOGQL_SAMPLING'),
   }
   return config
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const { createHash } = require('crypto')
 const { printSchema, responsePathAsArray } = require('graphql')
 const { LRUCache } = require('lru-cache')
 
-const { getConfig } = require('./config')
+const { getConfig, loadEnv } = require('./config')
 const { json, text, sendWithRetry } = require('./client')
 
 /**
@@ -252,6 +252,10 @@ function LogqlApolloPlugin(options = Object.create(null)) {
       }
     },
   }
+}
+
+LogqlApolloPlugin.fromEnv = function fromEnv() {
+  return LogqlApolloPlugin(loadEnv())
 }
 
 module.exports = LogqlApolloPlugin

--- a/src/index.js
+++ b/src/index.js
@@ -153,17 +153,15 @@ function isPersistedQueryNotFound({ request, source, errors }) {
 
 /**
  * @param {Partial<Config>} options
- * @returns {import('@apollo/server').ApolloServerPlugin}
+ * @returns {import('@apollo/server').ApolloServerPlugin<*>}
  */
 function LogqlApolloPlugin(options = Object.create(null)) {
-  const maybeConfig = getConfig(options)
+  const config = getConfig(options)
 
   // Disable if config was not loaded
-  if (maybeConfig == null) {
+  if (config == null) {
     return {}
   }
-
-  const config = maybeConfig
 
   // Disable in tests by default
   if (process.env.NODE_ENV === 'test' && !config.runInTests) {

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,4 +1,5 @@
 const initPlugin = require('../')
+const { getConfig, loadEnv } = require('../src/config')
 
 describe('Config Validation', () => {
   beforeAll(() => {
@@ -39,20 +40,57 @@ describe('Config Validation', () => {
   it('load config from env', () => {
     process.env.LOGQL_API_KEY = 'logql:FAKE_API_KEY'
     process.env.LOGQL_ENVIRONMENT = 'dev'
-    process.env.LOGQL_TIMEOUT = '33'
+    process.env.LOGQL_ENDPOINT = ''
     process.env.LOGQL_SEND_VARIABLES = 'true'
     process.env.LOGQL_SEND_HEADERS = 't'
     process.env.LOGQL_RUN_IN_TESTS = '0'
     process.env.LOGQL_VERBOSE = '1'
+    process.env.LOGQL_TIMEOUT = '33'
     process.env.LOGQL_REPORT_INTERVAL_MS = '10000'
     process.env.LOGQL_REPORT_ENTRIES_THRESHOLD = '3'
-    process.env.LOGQL_CACHE_SIZE = '33'
+    process.env.LOGQL_CACHE_SIZE = ''
     process.env.LOGQL_SAMPLING = '0.9'
-    process.env.LOGQL_ENDPOINT = 'http://localhost'
     const plugin = initPlugin.fromEnv()
 
     expect(console.error).not.toHaveBeenCalled()
     expect(plugin).not.toEqual({})
+  })
+
+  it('generate correct config from env', () => {
+    process.env.LOGQL_API_KEY = 'logql:FAKE_API_KEY'
+    process.env.LOGQL_ENVIRONMENT = 'dev'
+    process.env.LOGQL_ENDPOINT = ''
+    process.env.LOGQL_SEND_VARIABLES = 'true'
+    process.env.LOGQL_SEND_HEADERS = 't'
+    process.env.LOGQL_RUN_IN_TESTS = '0'
+    process.env.LOGQL_VERBOSE = '1'
+    process.env.LOGQL_TIMEOUT = '33'
+    process.env.LOGQL_REPORT_INTERVAL_MS = '10000'
+    process.env.LOGQL_REPORT_ENTRIES_THRESHOLD = '3'
+    process.env.LOGQL_CACHE_SIZE = ''
+    process.env.LOGQL_SAMPLING = '0.9'
+
+    const config = getConfig(loadEnv())
+
+    expect(config).toEqual({
+      apiKey: process.env.LOGQL_API_KEY,
+      environment: process.env.LOGQL_ENVIRONMENT,
+      endpoint: 'https://ingress.logql.io',
+
+      sendVariables: true,
+      sendHeaders: true,
+      runInTests: false,
+      verbose: true,
+
+      timeout: Number(process.env.LOGQL_TIMEOUT),
+      reportIntervalMs: 10000,
+      reportEntriesThreshold: 3,
+      cacheSize: 16384,
+
+      sampling: 0.9,
+
+      agent: null,
+    })
   })
 
   it('log an error when passed a non-object', () => {
@@ -67,7 +105,7 @@ describe('Config Validation', () => {
     process.env.LOGQL_TIMEOUT = 'NOT_A_NUMBER!'
     const plugin = initPlugin.fromEnv()
     expect(console.error).toHaveBeenCalledWith(
-      '[logql-plugin][ERROR][init] Invalid environment variable: Expected a number, got NOT_A_NUMBER!'
+      '[logql-plugin][ERROR][init] Invalid environment value for LOGQL_TIMEOUT: Expected a number, got "NOT_A_NUMBER!"'
     )
     expect(plugin).toEqual({})
   })

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -30,9 +30,29 @@ describe('Config Validation', () => {
     expect(initPlugin(config)).not.toEqual({})
   })
 
+  it('ignore env by default', () => {
+    process.env.LOGQL_API_KEY = 'logql:FAKE_API_KEY'
+    expect(initPlugin({})).toEqual({})
+    expect(console.error).toHaveBeenCalledWith('[logql-plugin][ERROR][init] Invalid options: Required at "apiKey"')
+  })
+
   it('load config from env', () => {
     process.env.LOGQL_API_KEY = 'logql:FAKE_API_KEY'
-    expect(initPlugin({})).not.toEqual({})
+    process.env.LOGQL_ENVIRONMENT = 'dev'
+    process.env.LOGQL_TIMEOUT = '33'
+    process.env.LOGQL_SEND_VARIABLES = 'true'
+    process.env.LOGQL_SEND_HEADERS = 't'
+    process.env.LOGQL_RUN_IN_TESTS = '0'
+    process.env.LOGQL_VERBOSE = '1'
+    process.env.LOGQL_REPORT_INTERVAL_MS = '10000'
+    process.env.LOGQL_REPORT_ENTRIES_THRESHOLD = '3'
+    process.env.LOGQL_CACHE_SIZE = '33'
+    process.env.LOGQL_SAMPLING = '0.9'
+    process.env.LOGQL_ENDPOINT = 'http://localhost'
+    const plugin = initPlugin.fromEnv()
+
+    expect(console.error).not.toHaveBeenCalled()
+    expect(plugin).not.toEqual({})
   })
 
   it('log an error when passed a non-object', () => {
@@ -43,16 +63,24 @@ describe('Config Validation', () => {
   })
 
   it('log a warning when env variables are not matching types', () => {
+    process.env.LOGQL_API_KEY = 'logql:FAKE_API_KEY'
     process.env.LOGQL_TIMEOUT = 'NOT_A_NUMBER!'
-    expect(initPlugin({ apiKey: 'logql:FAKE_API_KEY' })).not.toEqual({})
+    const plugin = initPlugin.fromEnv()
     expect(console.error).toHaveBeenCalledWith(
-      '[logql-plugin][WARNING][init] Invalid values supplied as environment variables, ignoring: timeout: Invalid number input: "NOT_A_NUMBER!"'
+      '[logql-plugin][ERROR][init] Invalid environment variable: Expected a number, got NOT_A_NUMBER!'
     )
+    expect(plugin).toEqual({})
   })
 
   it('does nothing in tests by default', () => {
     process.env.NODE_ENV = 'test'
-    expect(initPlugin({ runInTests: false })).toEqual({})
+    expect(initPlugin({ apiKey: 'logql:FAKE_API_KEY' })).toEqual({})
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('can run in test when configured', () => {
+    process.env.NODE_ENV = 'test'
+    expect(initPlugin({ apiKey: 'logql:FAKE_API_KEY', runInTests: true })).not.toEqual({})
     expect(console.error).not.toHaveBeenCalled()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2003,13 +2003,6 @@ encoding@^0.1.13:
   dependencies:
     iconv-lite "^0.6.2"
 
-envalid@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/envalid/-/envalid-7.3.1.tgz#5bf6bbb4effab2d64a1991d8078b4ae38924f0d2"
-  integrity sha512-KL1YRwn8WcoF/Ty7t+yLLtZol01xr9ZJMTjzoGRM8NaSU+nQQjSWOQKKJhJP2P57bpdakJ9jbxqQX4fGTOicZg==
-  dependencies:
-    tslib "2.3.1"
-
 err-code@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
@@ -4755,11 +4748,6 @@ tsconfig-paths@^3.14.1:
     json5 "^1.0.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
-
-tslib@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
Instead of loading the config automatically from env and merging them with the option object, there is now a separate function to init from env:

```js
// from env:
const plugin = logql.fromEnv()

// with options:
const plugin = logql(options)
```

Remove `envalid` as a dependency.